### PR TITLE
feat: Add a tab manually to a group

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -113,10 +113,26 @@ button.bullet {
   background: none;
 }
 
+div.add-tab {
+  padding-bottom: 8px;
+  height: 20px;
+}
+
 button.add-tab {
   background: none;
   color: #21e6c1;
   border: none;
+  padding-left: 0.90em;
+  padding-right: 5px;
+}
+
+#add-tab-input {
+  display: none;
+  background: none;
+  border: 2px solid #393e46;
+  color: #eeeeee;;
+  width: 70%;
+  height: 100%;
 }
 
 .tab-group {
@@ -152,7 +168,6 @@ button.add-tab {
   line-height: 2em;
 }
 
-
 .number-of-tabs {
   font-weight: bold;
   color: #21e6c1;
@@ -160,7 +175,6 @@ button.add-tab {
   width: 5em;
   font-size: 16px;
 }
-
 
 .tab-group .divider {
   width: 2px;

--- a/css/style.css
+++ b/css/style.css
@@ -126,7 +126,7 @@ button.add-tab {
   padding-right: 5px;
 }
 
-#add-tab-input {
+.add-tab-input {
   display: none;
   background: none;
   border: 2px solid #393e46;

--- a/js/popup.js
+++ b/js/popup.js
@@ -115,7 +115,7 @@ document
   .getElementById("collapse-unselected")
   .addEventListener("click", () => onBtnClick(blacklist));
 
-document.getElementById("tab-manager").addEventListener("click", function () {
+document.getElementById("tab-manager").addEventListener("click", function() {
   const creating = browser.tabs.create({
     url: "index.html",
   });

--- a/js/tab-manager.js
+++ b/js/tab-manager.js
@@ -20,7 +20,8 @@ function restoreToNewWindow(groupID) {
 }
 
 function addTabManually(groupID) {
-  addTabInput = document.getElementById("add-tab-input");
+  const addTabInput = document.getElementsByClassName(
+    "add-tab-input" + " prop-" + groupID.toString())[0];
   addTabInput.style.display = "inline-block";
   addTabInput.focus();
 
@@ -28,15 +29,15 @@ function addTabManually(groupID) {
     addTabInput.value = "";
     addTabInput.style.display = "none";
     let title = url;
-    let currentTabList = store[groupID].tabList
+    let currentTabList = store[groupID].tabList;
 
     try {
       // getting title of the page, also checks if the URL is valid
       const response = await fetch(
         url,
         { mode: 'cors', headers: { 'Access-Control-Allow-Origin': '*' } }
-      )
-      const html = await response.text()
+      );
+      const html = await response.text();
       const doc = new DOMParser().parseFromString(html, "text/html");
       title = doc.querySelectorAll('title')[0].innerText;
     }
@@ -47,7 +48,7 @@ function addTabManually(groupID) {
       else {
         alert("Invalid URL. Please enter a valid URL.");
         console.debug(error);
-        return false
+        return;
       }
     }
 
@@ -68,7 +69,7 @@ function addTabManually(groupID) {
       .then(() => {
         window.location.reload();
         addTabInput.style.display = "none";
-        return true;
+        return;
       })
       .catch((err) => console.debug(err));
   };
@@ -76,24 +77,26 @@ function addTabManually(groupID) {
   addTabInput.addEventListener("keyup", function(event) {
     if (event.key === "Enter") {
       url = addTabInput.value;
-      if (url !== "") {
+      if (url.trim() !== "") {
         return createTab(url);
       }
       else {
         addTabInput.style.display = "none";
-        return false
+        addTabInput.value = "";
+        return;
       }
     }
   });
 
   addTabInput.addEventListener("focusout", () => {
     url = addTabInput.value;
-    if (url !== "") {
+    if (url.trim() !== "") {
       return createTab(url);
     }
     else {
       addTabInput.style.display = "none";
-      return false
+      addTabInput.value = "";
+      return;
     }
   });
 
@@ -225,7 +228,7 @@ function displayGroupList() {
     addTab.appendChild(addTabBtn);
     const addTabInput = document.createElement("input");
     addTabInput.setAttribute('type', 'text');
-    addTabInput.id = "add-tab-input";
+    addTabInput.className = "add-tab-input" + " prop-" + prop.toString();
     addTabInput.setAttribute("placeholder", "Enter URL of the tab to add");
     addTab.appendChild(addTabInput);
     list.appendChild(addTab);

--- a/js/tab-manager.js
+++ b/js/tab-manager.js
@@ -19,6 +19,86 @@ function restoreToNewWindow(groupID) {
   creating.then(onCreated, onError);
 }
 
+function addTabManually(groupID) {
+  addTabInput = document.getElementById("add-tab-input");
+  addTabInput.style.display = "inline-block";
+  addTabInput.focus();
+
+  async function createTab(url) {
+    addTabInput.value = "";
+    addTabInput.style.display = "none";
+    let title = url;
+    let currentTabList = store[groupID].tabList
+
+    try {
+      // getting title of the page, also checks if the URL is valid
+      const response = await fetch(
+        url,
+        { mode: 'cors', headers: { 'Access-Control-Allow-Origin': '*' } }
+      )
+      const html = await response.text()
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      title = doc.querySelectorAll('title')[0].innerText;
+    }
+    catch (error) {
+      if (error.name == 'TypeError') {
+        title = url;
+      }
+      else {
+        alert("Invalid URL. Please enter a valid URL.");
+        console.debug(error);
+        return false
+      }
+    }
+
+    let obj = {
+      url: url,
+      id: currentTabList[currentTabList.length - 1].id + 1,
+      title: title,
+      create: { pinned: false, cookieStoreId: "firefox-default", url: url }
+    };
+    currentTabList.push(obj);
+
+    const out = {
+      groupName: store[groupID].groupName,
+      tabList: currentTabList,
+    };
+    browser.storage.local
+      .set({ [groupID]: out })
+      .then(() => {
+        window.location.reload();
+        addTabInput.style.display = "none";
+        return true;
+      })
+      .catch((err) => console.debug(err));
+  };
+
+  addTabInput.addEventListener("keyup", function(event) {
+    if (event.key === "Enter") {
+      url = addTabInput.value;
+      if (url !== "") {
+        return createTab(url);
+      }
+      else {
+        addTabInput.style.display = "none";
+        return false
+      }
+    }
+  });
+
+  addTabInput.addEventListener("focusout", () => {
+    url = addTabInput.value;
+    if (url !== "") {
+      return createTab(url);
+    }
+    else {
+      addTabInput.style.display = "none";
+      return false
+    }
+  });
+
+}
+
 function initialise() {
   return browser.storage.local.get(null).then((localStore) => {
     store = localStore;
@@ -42,7 +122,7 @@ function displayGroupProperties(parent, id) {
   groupNameLabel.className = "group-name";
   groupNameLabel.title = "Enter the name of the group here";
 
-  groupNameLabel.addEventListener("keyup", function (event) {
+  groupNameLabel.addEventListener("keyup", function(event) {
     if (event.key === "Enter") {
       const out = {
         groupName: groupNameLabel.value,
@@ -91,6 +171,7 @@ function displayGroupList() {
 
     list.ondrop = (e) => listonDrop(e, prop, list);
 
+    // Creating elements for each item of a group
     store[prop].tabList.forEach((tab, i) => {
       const tabElement = document.createElement("div");
       tabElement.classList.add("tab-container");
@@ -132,6 +213,22 @@ function displayGroupList() {
 
       list.appendChild(tabElement);
     });
+
+    // Elements for adding tab manually
+    const addTab = document.createElement("div");
+    addTab.className = "add-tab";
+    const addTabBtn = document.createElement("button");
+    addTabBtn.className = "add-tab";
+    addTabBtn.innerHTML = "&#65291";
+    addTabBtn.setAttribute("prop", prop);
+    addTabBtn.title = "Click to add a new tab to this group (by URL)"
+    addTab.appendChild(addTabBtn);
+    const addTabInput = document.createElement("input");
+    addTabInput.setAttribute('type', 'text');
+    addTabInput.id = "add-tab-input";
+    addTabInput.setAttribute("placeholder", "Enter URL of the tab to add");
+    addTab.appendChild(addTabInput);
+    list.appendChild(addTab);
 
     const header = document.createElement("div");
     header.className = "header";
@@ -195,6 +292,11 @@ document.getElementById("group-list").addEventListener("click", (e) => {
       .catch((err) => console.log(err));
   }
 
+  if (e?.target.matches("button.add-tab")) {
+    const prop = e.target.getAttribute("prop");
+    return addTabManually(prop);
+  }
+
   if (e?.target.matches("div.tab-container") || e?.target.matches("span")) {
     const prop = e.target.getAttribute("prop");
     const i = Number(e.target.getAttribute("index"));
@@ -202,7 +304,9 @@ document.getElementById("group-list").addEventListener("click", (e) => {
       .create(store[prop].tabList[i].create)
       .catch((err) => console.debug(err));
   }
+
 });
+
 document.getElementById("group-list").addEventListener("auxclick", (e) => {
   if (e?.target.matches("button.restore")) {
     const prop = e.target.getAttribute("prop");

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "48": "icons/icon-48.png"
   },
 
-  "permissions": ["tabs", "storage", "cookies"],
+  "permissions": ["tabs", "storage", "cookies", "<all_urls>"],
 
   "browser_action": {
     "default_icon": "icons/icon-48.png",


### PR DESCRIPTION
Resolves #27 


A `+` button sits at the end of the tab-list, which opens an input box for taking the URL.
![Screenshot from 2021-08-31 06-09-38](https://user-images.githubusercontent.com/20405311/131423403-a8847c36-6188-42c1-9875-90c2e190b038.png)
![Screenshot from 2021-08-31 06-12-05](https://user-images.githubusercontent.com/20405311/131423504-7bd4d14d-24c8-49a5-ad40-b811fde5f591.png)


We then make a request to the URL to get its title, and also check if it's a valid URL.
If the URL is valid, it's added to the group's tab-list. If an invalid URL, we raise an alert.